### PR TITLE
Do not set compiler to mingw32 on Windows

### DIFF
--- a/setuptools_cythonize.py
+++ b/setuptools_cythonize.py
@@ -55,10 +55,6 @@ class CythonizeBuild(build, object):  # 'object' inheritance permits @property u
     def finalize_options(self):
         build.finalize_options(self)
 
-        if not self.compiler and platform.system() == 'Windows':
-            log.warn("No compiler provided, set it to mingw32 as default")
-            self.compiler = 'mingw32'
-
 
 class CythonizeBuildPy(build_py):
 


### PR DESCRIPTION
With this patch, msvc is used, which is the default for building
Python extensions on Windows.
Currently, one must force usage of msvc when building bdist_wheel and
installing with something like:

```
%PYTHON% -m pip install . -vv --global-option build --global-option --compiler=msvc --global-option build --global-option --cythonize
```

This kind of command will no longer work in the next major release of
pip: https://github.com/pypa/pip/issues/8368