### PR TITLE
Bugfix/incompatibility with setuptools 63.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def main():
         py_modules=["setuptools_cythonize"],
         include_package_data=True,
         install_requires=[
-            'setuptools>=36.2.0',
+            'setuptools>=36.2.0, <=63.3.0',
             'wheel>=0.29.0',
             'cython>=0.25.2'
         ],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def main():
         py_modules=["setuptools_cythonize"],
         include_package_data=True,
         install_requires=[
-            'setuptools>=36.2.0, <=63.3.0',
+            'setuptools>=63.4.0',
             'wheel>=0.29.0',
             'cython>=0.25.2'
         ],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def main():
         py_modules=["setuptools_cythonize"],
         include_package_data=True,
         install_requires=[
-            'setuptools>=63.4.0',
+            'setuptools>=36.2.0',
             'wheel>=0.29.0',
             'cython>=0.25.2'
         ],

--- a/setuptools_cythonize.py
+++ b/setuptools_cythonize.py
@@ -163,7 +163,13 @@ class CythonizeBdist(bdist):
         """Set 'wheel' as default format.
         """
         if "wheel" not in cls.format_commands:
-            cls.format_commands['wheel'] = ('bdist_wheel', "Python .whl file")
+            try:
+                cls.format_commands['wheel'] = ('bdist_wheel', "Python .whl file")
+            except TypeError:
+                # For backward compatibility with older distutils (stdlib)
+                cls.format_command['wheel'] = ('bdist_wheel', "Python .whl file")
+                cls.format_commands.append('wheel')
+            
             for keyos in cls.default_format:
                 cls.default_format[keyos] = 'wheel'
 

--- a/setuptools_cythonize.py
+++ b/setuptools_cythonize.py
@@ -163,8 +163,7 @@ class CythonizeBdist(bdist):
         """Set 'wheel' as default format.
         """
         if "wheel" not in cls.format_commands:
-            cls.format_command['wheel'] = ('bdist_wheel', "Python .whl file")
-            cls.format_commands.append('wheel')
+            cls.format_commands['wheel'] = ('bdist_wheel', "Python .whl file")
             for keyos in cls.default_format:
                 cls.default_format[keyos] = 'wheel'
 


### PR DESCRIPTION
setuptools removed the `format_command` property of the `bdist` command, which setuptools-cythonize relies on.

This results in the following error:
```
File "D:\win_temp\pip-build-env-avucl34u\overlay\Lib\site-packages\setuptools_cythonize.py", line 166, in set_default_wheel_format
    cls.format_command['wheel'] = ('bdist_wheel', "Python .whl file")
AttributeError: type object 'CythonizeBdist' has no attribute 'format_command'
```

This PR contains two solutions:
- It still works with setuptools versions <=63.3.0, so a workaround is to constrain the setuptools version to that (commit 318c6b4d13961409472485febeaa0ca47636f27d)
- A future proof, way is in the second commit (aadd7667c7fc103b7e13ad4a0154f990fbcecd41), where only the `format_commands` `dict` (note the `s` at the end) is used, because since 63.3.0 this `dict` will retain the order, the list is not required/supported anymore. Because this is a fix that is not compatible with setuptools <63.3.0 the constraint in the `setup.py` was updated.

@anxuae I would suggest to make separate releases for the two commits, so that people who cannot use setuptools 63.4.0 for any reason can still fall back to the backwards compatible first fix.